### PR TITLE
Attempt to fix more-ci

### DIFF
--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -59,7 +59,9 @@ jobs:
       # we already check the build with this option in the main CI job, we
       # disable it here unconditionally for simplicity.
       - name: Edit dune-project
-        run: sed -i '/(implicit_transitive_deps false)/d' dune-project
+        run: |
+          sed -i.bak '/(implicit_transitive_deps false)/d' dune-project
+          rm dune-project.bak
 
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the

--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -59,9 +59,9 @@ jobs:
       # we already check the build with this option in the main CI job, we
       # disable it here unconditionally for simplicity.
       - name: Edit dune-project
+        shell: pwsh
         run: |
-          sed -i.bak '/(implicit_transitive_deps false)/d' dune-project
-          rm dune-project.bak
+          (Get-Content dune-project) -notmatch '\(implicit_transitive_deps false\)' | Set-Content dune-project
 
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the

--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -55,6 +55,12 @@ jobs:
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
+      # This construct is not well supported by older OCaml versions. Given that
+      # we already check the build with this option in the main CI job, we
+      # disable it here unconditionally for simplicity.
+      - name: Edit dune-project
+        run: sed -i '/(implicit_transitive_deps false)/d' dune-project
+
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the
       # tests that are checked for every combination of os and ocaml-compiler.


### PR DESCRIPTION
Attempt to disable the use of `(implicit_transitive_dependencies false)` in more-ci due to it failing with older OCaml version tested by the build matrix.